### PR TITLE
adding middleware layer to resolve CORS error with React

### DIFF
--- a/build/db-handler/app/main.py
+++ b/build/db-handler/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, responses
+from fastapi.middleware.cors import CORSMiddleware
 from app.routers import figures_router, whiteboard_router, display_router
 from app.dependencies.database import cal_col
 from app import help_scripts
@@ -18,10 +19,24 @@ tags_metadata = [
     }
 ]
 
+origins = [
+    "http://0.0.0.0:3000",
+    "http://localhost:3000"
+]
+
 app = FastAPI(
     title="Lambda DB Handler",
     openapi_tags=tags_metadata
 )
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 app.include_router(figures_router.router)
 app.include_router(whiteboard_router.router)
@@ -42,3 +57,4 @@ async def reset(reset: bool = False):
 @app.get("/dump", summary="DUMPS THE MONGODB FOR TESTING")
 async def dump():
     return {"body": list(cal_col.find({}, {"_id": 0}))}
+


### PR DESCRIPTION
adding middleware layer to resolve CORS error with React. when HTTP requests are made from the browser (i.e. within front-end components), the localhost address of the React development server hosting the display web app should now be received as an allowed origin. we may need to look into this again if we plan to run the database on a different machine than the one running the database instance, but for now it should work i think?