### PR TITLE
logic (no styling) for best available time suggestion

### DIFF
--- a/build/ui-display/frontend-app/src/App.js
+++ b/build/ui-display/frontend-app/src/App.js
@@ -1,7 +1,7 @@
 import './App.css';
 import DateWidget from './components/widgets/DateWidget';
 import ClockWidget from './components/widgets/ClockWidget';
-
+import SuggestedTimeWidget from './components/widgets/SuggestedTimeWidget';
 
 function App() {
   return (
@@ -12,6 +12,7 @@ function App() {
       </header>
       <ClockWidget />
       <div className="Sky-box">
+        <SuggestedTimeWidget />
         here's the sky
         <div className='Grass-box'>
           here's the grass :D
@@ -22,3 +23,4 @@ function App() {
 }
 
 export default App;
+

--- a/build/ui-display/frontend-app/src/components/Constants.js
+++ b/build/ui-display/frontend-app/src/components/Constants.js
@@ -1,0 +1,10 @@
+export const TIMESLOT_LEN = 15;
+export const FAMILY_NAME = "family";
+export const USERS = ["user_1", "user_2", "user_3", "user_4", FAMILY_NAME];
+export const DAYS = ["sunday", "monday", "tuesday", "wednesday", 
+"thursday", "friday", "saturday"]; // ECMAScript ordering
+// Dictionary for readable conversions between ECMAScript Date format 
+// (begins on Sunday) and app calendar (begins on Monday)
+// TODO this might be something we set in the config file?
+export const DAY_POSITIONS = {"monday": 0, "tuesday": 1, 
+"wednesday": 2, "thursday": 3, "friday": 4, "saturday": 5, "sunday": 6};

--- a/build/ui-display/frontend-app/src/components/widgets/SuggestedTimeWidget.js
+++ b/build/ui-display/frontend-app/src/components/widgets/SuggestedTimeWidget.js
@@ -1,0 +1,95 @@
+import { useState, useEffect } from 'react';
+import * as Constants from '../Constants';
+import './Widgets.css';
+
+export default function SuggestedTimeWidget() {
+    
+    /* SETTINGS FOR CONFIG:
+    - how many times to suggest if there's more than 1 appropriate?
+    - what to display if there are none appropriate?
+        - SWITCH to next best times instead?
+        - or explicitly say there's no good times and direct to DIFFERENT widget?
+    - when there's multiple matches, what do we rank by?
+        - next nearest time?
+
+    - if the week is nearly over, do you treat entries like they wrap to the next
+    week coming (e.g. on a friday, stuff written on monday becomes NEXT monday),
+    or just cut the week off after the remaining fri, sat, sun?
+
+    - day the week starts? (remember to update Constants file accordingly.
+        if this is going to change dynamically maybe move that dictionary 
+        to a Utilities file instead).
+
+    - should we report how long eveyrbody is free for, i.e. does it span multiple
+    time slots? or should they just be able to set the minimum number of consecutive
+    time slots required for it to "count"?
+    */
+    const currentToTimeSlotNum = () => {
+        const now = new Date();
+        const hour_slot = now.getHours() * 60 / Constants.TIMESLOT_LEN;
+        const minute_slot = Math.floor(now.getMinutes() / Constants.TIMESLOT_LEN) * Constants.TIMESLOT_LEN / Constants.TIMESLOT_LEN;
+        return hour_slot + minute_slot;
+    }
+
+    const dayAndTimeToDate = (day, time) => {
+        const timeOptions = {
+            hour: "numeric",
+            minute: "2-digit",
+            hour12: true
+        };
+        const timeParts = time.split(":");
+        const prettyDate = (day.charAt(0).toUpperCase() 
+            + day.slice(1)) + " " 
+            + (new Date(new Date().setHours(timeParts[0], 
+                timeParts[1])).toLocaleTimeString('en-AU', timeOptions));
+        return prettyDate;
+    }
+
+
+    const [suggestedTime, setSuggestedTime] = useState("");
+    const [loading, setLoading] = useState(true);
+    const baseURL = 'https://localhost:8000/display/';
+
+
+    useEffect(() => {
+        /* DEFAULT BEHAVIOUR: GET SINGLE RECOMMENDATION OF NEXT NEAREST TIME */
+        const fetchData = async () => {
+            const response = await fetch("http://localhost:8000/display/user-free-timeslots");
+            const data = await response.json();
+            if (data && data.body) {
+                const timeSlotsAllWeek = Array.from(data.body);
+                // filter out any days already passed
+                // TODO what do we do when the week is nearly over?
+                const dayName = Constants.DAYS[new Date().getDay()];
+                const timeSlots = timeSlotsAllWeek.filter(timeSlot => 
+                    (Constants.DAY_POSITIONS[timeSlot.day] 
+                        > Constants.DAY_POSITIONS[dayName]) 
+                        || (Constants.DAY_POSITIONS[timeSlot.day] 
+                            === Constants.DAY_POSITIONS[dayName] 
+                            && timeSlot.slot_num > currentToTimeSlotNum()));
+                setSuggestedTime(dayAndTimeToDate(timeSlots[0]['day'],
+                    timeSlots[0]['time']));
+                setLoading(false);
+            }
+        };
+
+        fetchData();
+    }, []); // Empty dependency array means this effect runs once when component mounts
+
+
+    return (
+        <div className="SuggestedTime">
+            <header>
+                {loading ?
+                    <p>Oops! Check back in a sec.</p> :
+                    <>
+                        <h1>Suggested Time 🪩</h1>
+                        <h3>Everybody is next free at {suggestedTime}.</h3>
+                    </>
+                }
+            </header>
+        </div>
+    );
+}
+
+


### PR DESCRIPTION
### **approve & merge the busiest-person widget first!**
won't work on browser until we merge with a version that has the latest db stuff, i.e. the CORS middleware fix. also will potentially need to communicate with a config file at some point, but should minimally work. also if we speed up the clock at all for the demo we're gonna need to change the date source as this just uses new Date(), i.e. the current system time. 